### PR TITLE
Check if positions and transactions are empty

### DIFF
--- a/pyfolio/timeseries.py
+++ b/pyfolio/timeseries.py
@@ -735,9 +735,9 @@ def perf_stats(
     for stat_func in SIMPLE_STAT_FUNCS:
         stats[STAT_FUNC_NAMES[stat_func.__name__]] = stat_func(returns)
 
-    if positions is not None:
+    if (positions is not None) and (not positions.empty):
         stats["Gross leverage"] = gross_lev(positions).mean()
-        if transactions is not None:
+        if (transactions is not None) and (not transactions.empty):
             stats["Daily turnover"] = get_turnover(
                 positions, transactions, turnover_denom
             ).mean()


### PR DESCRIPTION
In some cases, especially with live_start_date enabled in function create_full_tear_sheet(), there could chance that positions or transactions are empty after live_start_date. That make function get_turnover() return "IndexError: single positional indexer is out-of-bounds". That needs to be checked in function perf_stats(). Checking if positions and transactions are None is not enough. The dataframe could also be empty but not None.

![image](https://user-images.githubusercontent.com/3151287/151647930-8297c6e0-97d0-4347-8886-1eee5c1cb174.png)


Signed-off-by: Zhiyi Sun <zhiyisun@msn.com>