### PR TITLE
bugfix for quantopian/pyfolio#678

### DIFF
--- a/pyfolio/plotting.py
+++ b/pyfolio/plotting.py
@@ -447,11 +447,12 @@ def plot_drawdown_periods(returns, top=10, ax=None, **kwargs):
     for i, (peak, recovery) in df_drawdowns[
         ["Peak date", "Recovery date"]
     ].iterrows():
-        if pd.isnull(recovery):
-            recovery = returns.index[-1]
-        ax.fill_between(
-            (peak, recovery), lim[0], lim[1], alpha=0.4, color=colors[i]
-        )
+        if not pd.isna(peak) and not pd.isna(recovery):
+            if pd.isnull(recovery):
+                recovery = returns.index[-1]
+            ax.fill_between(
+                (peak, recovery), lim[0], lim[1], alpha=0.4, color=colors[i]
+            )
     ax.set_ylim(lim)
     ax.set_title("Top %i drawdown periods" % top)
     ax.set_ylabel("Cumulative returns")


### PR DESCRIPTION
this PR fixes quantopian/pyfolio#678 by skipping drawdowns while plotting that have no peak or recovery set in `plot_drawdown_periods()`